### PR TITLE
fix: 从注册表读取真实的 Windows 桌面路径

### DIFF
--- a/shortcut_windows.go
+++ b/shortcut_windows.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"golang.org/x/sys/windows/registry"
 )
 
 // CreateChineseShortcut 创建一个运行动态汉化的“原名字 中文”桌面快捷方式
@@ -24,9 +26,8 @@ func CreateChineseShortcut(cfg AppConfig) error {
 	selfDir := filepath.Dir(selfExeAbs)
 
 	// 计算桌面路径
-	userProfile := os.Getenv("USERPROFILE")
-	desktopDir := filepath.Join(userProfile, "Desktop")
-	publicDesktop := `C:\Users\Public\Desktop`
+	desktopDir := getDesktopPath()
+	publicDesktop := getPublicDesktopPath()
 
 	// 查找原快捷方式的可能名字
 	lnkName := cfg.Name + ".lnk"
@@ -121,4 +122,34 @@ $newLnk.Save()
 
 	fmt.Printf("[成功] 已在桌面创建快捷方式: %s\n", targetLnkPath)
 	return nil
+}
+
+func getDesktopPath() string {
+	k, err := registry.OpenKey(registry.CURRENT_USER, `Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders`, registry.QUERY_VALUE)
+	if err == nil {
+		defer k.Close()
+		val, _, err := k.GetStringValue("Desktop")
+		if err == nil && val != "" {
+			if expanded, err := registry.ExpandString(val); err == nil {
+				return expanded
+			}
+			return os.ExpandEnv(val)
+		}
+	}
+	return filepath.Join(os.Getenv("USERPROFILE"), "Desktop")
+}
+
+func getPublicDesktopPath() string {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders`, registry.QUERY_VALUE)
+	if err == nil {
+		defer k.Close()
+		val, _, err := k.GetStringValue("Common Desktop")
+		if err == nil && val != "" {
+			if expanded, err := registry.ExpandString(val); err == nil {
+				return expanded
+			}
+			return os.ExpandEnv(val)
+		}
+	}
+	return `C:\Users\Public\Desktop`
 }


### PR DESCRIPTION
- 修复了用户修改默认桌面路径（如移至 D 盘）后，生成的快捷方式不在桌面上的问题。
- 引入 golang.org/x/sys/windows/registry 包。
- 动态读取 User Shell Folders 注册表项以获取当前用户桌面和公共桌面的实际位置。
- 为注册表读取添加容错机制，失败时自动 fallback 至默认环境变量路径。